### PR TITLE
Fix digest test routes

### DIFF
--- a/src/oc/digest/app.clj
+++ b/src/oc/digest/app.clj
@@ -49,13 +49,13 @@
       (test-digest jwtoken medium frequency)
       {:body "A login with a valid JWT cookie required for test digest request." :status 401}))
 
-  ([jwtoken :guard string? "email" frequency :guard d-or-w]
-  (if-let [digest-request (data/digest-request-for jwtoken frequency :email)]
+  ([jwtoken :guard string? _medium :guard #(= % "email") frequency :guard d-or-w]
+  (if-let [digest-request (data/digest-request-for jwtoken frequency :email false)]
     {:body "Email digest test initiated." :status 200}
     {:body "Failed to initiate an email digest test." :status 500}))
 
-  ([jwtoken :guard string? _medium frequency :guard d-or-w]
-  (if-let [digest-request (data/digest-request-for jwtoken frequency :slack)]
+  ([jwtoken :guard string? _medium :guard #(= % "slack") frequency :guard d-or-w]
+  (if-let [digest-request (data/digest-request-for jwtoken frequency :slack false)]
     {:body "Slack digest test initiated." :status 200}
     {:body "Failed to initiate a Slack digest test." :status 500}))
 

--- a/src/oc/digest/app.clj
+++ b/src/oc/digest/app.clj
@@ -45,18 +45,19 @@
   
   ([cookies :guard map? medium frequency]
     (if-let* [jwtoken (-> cookies (get cookie-name) :value)
-              _check (jwt/check-token jwtoken c/passphrase)]
+              _valid? (jwt/valid? jwtoken c/passphrase)]
       (test-digest jwtoken medium frequency)
-      {:body "A login with a valid JWT cookie required for test digest request." :status 401}))
+      {:body "An unexpired login with a valid JWT cookie required for test digest request.\n
+              Please refresh your login with the Web UI before making this request." :status 401}))
 
   ([jwtoken :guard string? _medium :guard #(= % "email") frequency :guard d-or-w]
   (if-let [digest-request (data/digest-request-for jwtoken frequency :email false)]
-    {:body "Email digest test initiated." :status 200}
+    {:body (str "Email " (name frequency) " digest test initiated.") :status 200}
     {:body "Failed to initiate an email digest test." :status 500}))
 
   ([jwtoken :guard string? _medium :guard #(= % "slack") frequency :guard d-or-w]
   (if-let [digest-request (data/digest-request-for jwtoken frequency :slack false)]
-    {:body "Slack digest test initiated." :status 200}
+    {:body (str "Slack " (name frequency) " digest test initiated.") :status 200}
     {:body "Failed to initiate a Slack digest test." :status 500}))
 
   ([_jwtoken :guard string? _medium _frequency]


### PR DESCRIPTION
Bug: when visiting localhost:3008/_/{email|slack|/{weekly/daily} it fails with:
`Wrong number of args (3) passed to: data/digest-request-for` (full stack trace here https://sentry.io/opencompany/oc-iacopo-digest/issues/437065182/).

To test:
- setup an org with Slack
- make sure it has some posts for the last 7 days
- start the digest service (this branch)
- start the email service (mainline)
- [x] visit http://localhost:3008/_/slack/daily
- [x] page body should be "Slack digest test initiated."
- [x] check slack for the daily digest
- [x] visit http://localhost:3008/_/slack/weekly and check slack for the weekly digest
- [x] page body should be "Slack digest test initiated."
- [x] check slack for the weekly digest
- [x] visit http://localhost:3008/_/email/daily and check your email for the daily digest
- [x] page body should be "Email digest test initiated."
- [x] check your email for the daily digest
- [x] visit http://localhost:3008/_/email/weekly and check your email for the weekly digest
- [x] page body should be "Email digest test initiated."
- [x] check your email for the daily digest