### PR TITLE
Update digest link location in web UI

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -71,7 +71,7 @@
         ;; NB: clj-time is pulled in by oc.lib
         ;; NB: joda-time is pulled in by oc.lib via clj-time
         ;; NB: commons-codec pulled in by oc.lib
-        [midje "1.9.2-alpha2" :exclusions [joda-time clj-time commons-codec]] 
+        [midje "1.9.2-alpha3" :exclusions [joda-time clj-time commons-codec]] 
       ]
       :plugins [
         ;; Example-based testing https://github.com/marick/lein-midje

--- a/src/oc/digest/async/digest_request.clj
+++ b/src/oc/digest/async/digest_request.clj
@@ -61,7 +61,7 @@
 ;; ----- Activity → Digest -----
 
 (defn- post-url [org-slug board-slug uuid published-at]
-  (str (s/join "/" [config/ui-server-url org-slug board-slug "post" uuid]) "?at=" published-at))
+  (str (s/join "/" [config/ui-server-url org-slug "all-posts"]) "?at=" published-at))
 
 (defn- post [org-slug post]
   (let [comments (link-for "comments" post)]

--- a/src/oc/digest/schedule.clj
+++ b/src/oc/digest/schedule.clj
@@ -37,7 +37,7 @@
   ([conn :guard map? frequency skip-send?]
   (let [user-list (user-res/list-users-for-digest conn frequency)]
     (timbre/info "Initiating" frequency "run for" (count user-list) "users...")
-    (digest-run user-list frequency)))
+    (digest-run user-list frequency skip-send?)))
 
   ([user-list :guard sequential? frequency] (digest-run user-list frequency false))
 


### PR DESCRIPTION
Move digest link from direct to post, to timestamp in all-posts.

Test w/ web UI.

- [x] Setup a user w/ email digest
- [x] Create a few new posts
- [x] Force a digest run (see Digest README)
- [x] Click on the different links in the email digest, do they go to the right spot in All Posts?
- [x] Change the user to Slack digest
- [x] Force a digest run 
- [x] Click on the different links in the Slack digest, do they go to the right spot in All Posts?
- [x] Merge
- [x] Deploy
- [ ] Get over yourself