### PR TITLE
Add Must see and Video to digest

### DIFF
--- a/src/oc/digest/async/digest_request.clj
+++ b/src/oc/digest/async/digest_request.clj
@@ -17,7 +17,9 @@
    :publisher lib-schema/Author
    :published-at lib-schema/ISO8601
    :comment-count schema/Int
-   :comment-authors [lib-schema/Author]})
+   :comment-authors [lib-schema/Author]
+   :must-see (schema/maybe schema/Bool)
+   :video-id (schema/maybe lib-schema/NonBlankStr)})
 
 (def DigestBoard
   {:name lib-schema/NonBlankStr
@@ -72,7 +74,9 @@
      :publisher (:publisher post)
      :published-at (:published-at post)
      :comment-count (or (:count comments) 0)
-     :comment-authors (or (map #(dissoc % :created-at) (:authors comments)) [])}))
+     :comment-authors (or (map #(dissoc % :created-at) (:authors comments)) [])
+     :must-see (:must-see post)
+     :video-id (:video-id post)}))
 
 (defn- board [org-slug posts]
   {:name (:board-name (first posts))


### PR DESCRIPTION
Card: https://trello.com/c/Jl882yQ4
Abstract: https://share.goabstract.com/844204a3-2047-42e0-9a89-1467ade032a2

Related PRs:
- [storage](https://github.com/open-company/open-company-storage/pull/164)
- [bot](https://github.com/open-company/open-company-bot/pull/36)
- [email](https://github.com/open-company/open-company-email/pull/27)

To test:
- with your Slack org
- publish a Must see post with a ziggeo video
- publish a must see only post
- publish a video only post
- publish a post w/o video and no must see
- visit http://localhost:3008/_/slack/weekly
- [x] do you see the 4 posts? Good
- [x] do they have the needed prefix? Good
- [x] do they have the user avatar? Good
- now share a must see entry with a video via Slack
- [x] do you have the same color of the vertical line as in the digest? Good
- [x] do you see the user name and avatar? Good
- [ ] do you see the right prefix? Good
- visit http://localhost:3008/_/email/weekly
- check your email
- [x] do you see the 4 posts? Good
- [x] do they respect the abstract design? Good
- [x] do the sublines are vertically aligned with the headline? Good
- now share a must see entry with a video via email
- [x] do you see the Must see and video icons? Good