### PR TITLE
Generate and send an id token with the digest url.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
     [clojure.java-time "0.3.2"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.29alpha1"]
+    [open-company/lib "0.16.29alpha2"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
     [clojure.java-time "0.3.2"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.29alpha6"]
+    [open-company/lib "0.16.29"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
     [clojure.java-time "0.3.2"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.26alpha"]
+    [open-company/lib "0.16.26alpha4"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
     [clojure.java-time "0.3.2"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.26alpha4"]
+    [open-company/lib "0.16.29alpha1"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
     [clojure.java-time "0.3.2"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.19"]
+    [open-company/lib "0.16.26alpha"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
     [clojure.java-time "0.3.2"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.29alpha2"]
+    [open-company/lib "0.16.29alpha3"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
     [clojure.java-time "0.3.2"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.29alpha3"]
+    [open-company/lib "0.16.29alpha6"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let

--- a/src/oc/digest/async/digest_request.clj
+++ b/src/oc/digest/async/digest_request.clj
@@ -5,8 +5,8 @@
             [amazonica.aws.sqs :as sqs]
             [taoensso.timbre :as timbre]
             [schema.core :as schema]
-            [oc.lib.jwt :as jwt]
             [oc.lib.schema :as lib-schema]
+            [oc.lib.jwt :as jwt]
             [oc.digest.config :as config]))
 
 ;; ----- Schema -----
@@ -61,18 +61,27 @@
   (let [claims (:claims (jwt/decode jwtoken))]
     (str "user-id " (:user-id claims) " email " (:email claims))))
 
+(defn log-claims [claims]
+  (str "user-id " (:user-id claims) " email " (:email claims)))
+
 (defn link-for [rel {links :links}]
   (some #(if (= (:rel %) rel) % false) links))
 
+
 ;; ----- Activity → Digest -----
 
-(defn- post-url [org-slug board-slug uuid published-at]
-  (str (s/join "/" [config/ui-server-url org-slug "all-posts"]) "?at=" published-at))
+(defn- post-url [org-slug board-slug published-at id-token]
+  (str (s/join "/" [config/ui-server-url org-slug "all-posts"]) "?at=" published-at "&id=" id-token))
 
-(defn- post [org-slug post]
-  (let [comments (link-for "comments" post)]
+(defn- post [org-slug claims post]
+  (let [comments (link-for "comments" post)
+        token-claims (-> claims
+                         (assoc :team-id (first (:teams claims)))
+                         (assoc :org-uuid (:org-uuid claims))
+                         (assoc :secure-uuid (:secure-uuid post)))
+        id-token (jwt/generate-id-token token-claims config/passphrase)]
     {:headline (:headline post)
-     :url (post-url org-slug (:board-slug post) (:uuid post) (:published-at post))
+     :url (post-url org-slug (:board-slug post) (:published-at post) id-token)
      :publisher (:publisher post)
      :published-at (:published-at post)
      :comment-count (or (:count comments) 0)
@@ -82,23 +91,22 @@
      :video-image (or (:video-image post) "")
      :video-duration (or (:video-duration post) "")}))
 
-(defn- board [org-slug posts]
+(defn- board [org-slug claims posts]
   {:name (:board-name (first posts))
-   :posts (map #(post org-slug %) (reverse (sort-by :published-at posts)))})
+   :posts (map #(post org-slug claims %) (reverse (sort-by :published-at posts)))})
 
-(defn- boards [org-slug activity]
+(defn- boards [org-slug activity claims]
   (let [by-board (group-by :board-name activity)
         board-names (sort (keys by-board))]
-    (map #(board org-slug (get by-board %)) board-names)))
+    (map #(board org-slug claims (get by-board %)) board-names)))
 
 ;; ----- Digest Request Trigger -----
 
 (defun- trigger-for
   
   ;; Slack
-  ([trigger jwtoken :slack]
+  ([trigger claims :slack]
   (let [team-id (:team-id trigger)
-        claims (:claims (jwt/decode jwtoken))
         first-name (:first-name claims)
         last-name (:last-name claims)
         bots (:slack-bots claims)
@@ -115,9 +123,8 @@
       (assoc :last-name last-name))))
 
   ;; Email
-  ([trigger jwtoken :email]
-  (let [claims (:claims (jwt/decode jwtoken))
-        email (:email claims)
+  ([trigger claims :email]
+  (let [email (:email claims)
         first-name (:first-name claims)
         last-name (:last-name claims)]
     (-> trigger
@@ -126,7 +133,7 @@
      (assoc :last-name last-name)))))
     
 (defn ->trigger [{logo-url :logo-url org-slug :slug org-name :name org-uuid :uuid team-id :team-id :as org}
-                 activity frequency]
+                 activity frequency claims]
   (let [trigger {:type :digest
                  :digest-frequency (keyword frequency)
                  :org-slug org-slug
@@ -138,25 +145,25 @@
                                     :logo-width (:logo-width org)
                                     :logo-height (:logo-height org)})
                     trigger)]
-    (assoc with-logo :boards (boards org-slug activity))))
+    (assoc with-logo :boards (boards org-slug activity (assoc claims :org-uuid org-uuid)))))
 
-(defn send-trigger! [trigger jwtoken medium]
+(defn send-trigger! [trigger claims medium]
   (schema/validate DigestTrigger trigger) ; sanity check
   (let [slack? (= (keyword medium) :slack)
         queue (if slack? config/aws-sqs-bot-queue config/aws-sqs-email-queue)
-        medium-trigger (trigger-for trigger jwtoken medium)
+        medium-trigger (trigger-for trigger claims medium)
         trigger-schema (if slack? SlackTrigger EmailTrigger)]
     (if (lib-schema/valid? trigger-schema medium-trigger)
       ;; All is well, do the needful
       (do
-        (timbre/info "Digest request to queue:" queue "for:" (log-token jwtoken))
-        (timbre/trace "Digest request:" trigger "for:" (log-token jwtoken))
-        (timbre/info "Sending request to queue:" queue "for:" (log-token jwtoken))
+        (timbre/info "Digest request to queue:" queue "for:" (log-claims claims))
+        (timbre/trace "Digest request:" trigger "for:" (log-claims claims))
+        (timbre/info "Sending request to queue:" queue "for:" (log-claims claims))
         (sqs/send-message
           {:access-key config/aws-access-key-id
            :secret-key config/aws-secret-access-key}
           queue
           medium-trigger)
-        (timbre/info "Request sent to:" queue "for:" (log-token jwtoken)))
+        (timbre/info "Request sent to:" queue "for:" (log-claims claims)))
       ;; Trigger is no good
-      (timbre/warn "Digest request failed with invalid trigger:" trigger "for:" (log-token jwtoken)))))
+      (timbre/warn "Digest request failed with invalid trigger:" trigger "for:" (log-claims claims)))))

--- a/src/oc/digest/async/digest_request.clj
+++ b/src/oc/digest/async/digest_request.clj
@@ -70,8 +70,8 @@
 
 ;; ----- Activity → Digest -----
 
-(defn- post-url [org-slug board-slug published-at id-token]
-  (str (s/join "/" [config/ui-server-url org-slug "all-posts"]) "?at=" published-at "&id=" id-token))
+(defn- post-url [org-slug board-slug secure-id id-token]
+  (str (s/join "/" [config/ui-server-url org-slug "post" secure-id]) "?id=" id-token))
 
 (defn- post [org-slug claims post]
   (let [comments (link-for "comments" post)
@@ -81,7 +81,7 @@
                          (assoc :secure-uuid (:secure-uuid post)))
         id-token (jwt/generate-id-token token-claims config/passphrase)]
     {:headline (:headline post)
-     :url (post-url org-slug (:board-slug post) (:published-at post) id-token)
+     :url (post-url org-slug (:board-slug post) (:secure-uuid post) id-token)
      :publisher (:publisher post)
      :published-at (:published-at post)
      :comment-count (or (:count comments) 0)

--- a/src/oc/digest/data.clj
+++ b/src/oc/digest/data.clj
@@ -8,6 +8,7 @@
     [clj-http.client :as httpc]
     [taoensso.timbre :as timbre]
     [cheshire.core :as json]
+    [oc.lib.jwt :as jwt]
     [oc.digest.async.digest-request :as d-r]
     [oc.digest.config :as c]))
 
@@ -50,7 +51,8 @@
                         "with:" (log-activity activity))
           
           ;; Trigger the digest request for the appropriate medium
-          :else (d-r/send-trigger! (d-r/->trigger org activity frequency) jwtoken medium)))
+          :else (let [claims (:claims (jwt/decode jwtoken))]
+                  (d-r/send-trigger! (d-r/->trigger org activity frequency claims) claims medium))))
 
       ;; Failed to get activity for the digest
       (timbre/warn "Error requesting:" activity-url "for:" (d-r/log-token jwtoken) "start:" start


### PR DESCRIPTION
This is the main PR since it kicks off the entire process.

This change uses the new identity token in open-company-lib and attaches the token to the urls for each post.  Clicking on that post will allow you to view it without logging in.

The dependencies:
https://github.com/open-company/open-company-lib/pull/47
https://github.com/open-company/open-company-storage/pull/178
https://github.com/open-company/open-company-auth/pull/70

https://github.com/open-company/open-company-web/pull/757

To test:
- Create a new entry in your org
- Make sure you have a user with either daily slack or email notifications on.
- Run `lein run-daily` to generate a new daily digest.
- [x] when you click on the link and you are logged in does carrot take you to the post with all posts in view (normal expected behavior)?
- [x] when you click on the link ,when you are logged out ,does it show the full post?

- Create a new post (make sure a different user will receive the digest)
- Don't have the user, receiving the digest, read the post yet.
- run the digest `lein run-daily`
- [x] after clicking on the link, while logged out, does the post get mark as read?