### PR TITLE
Switch to only daily digest. TZ aware.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_script:
   - "echo $JAVA_OPTS"
   - lein clean
 script:
+- lein test!
 - lein eastwood
 - lein kibit
 branches:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Prospective users of [Carrot](https://carrot.io/) should get started by going to
 
 Most of the dependencies are internal, meaning [Leiningen](https://github.com/technomancy/leiningen) will handle getting them for you. There are a few exceptions:
 
-* [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) - a Java 8 JRE is needed to run Clojure
+* [Java 8+](http://www.oracle.com/technetwork/java/javase/downloads/index.html) - a Java 8+ JRE is needed to run Clojure
 * [Leiningen](https://github.com/technomancy/leiningen) v2.7.1+ - Clojure's build and dependency management tool
 * [RethinkDB](http://rethinkdb.com/) v2.3.6+ - a multi-modal (document, key/value, relational) open source NoSQL database
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 
 Distributed under the [GNU Affero General Public License Version 3](https://www.gnu.org/licenses/agpl-3.0.en.html).
 
-Copyright © 2017-2018 OpenCompany, LLC
+Copyright © 2017-2019 OpenCompany, LLC
 
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To get started, head to: [Carrot](https://carrot.io/)
 
 ## Overview
 
-Daily and Weekly Slack and Email digests.
+Daily Slack and Email digests.
 
 ## Local Setup
 
@@ -213,37 +213,23 @@ To create a production build run:
 lein build
 ```
 
-To initiate a test of a daily or weekly digest run (nothing will be sent out):
+To initiate a test digest run (nothing will be sent out):
 
 ```console
-lein dry-run-daily
+lein dry-run
 ```
 
--or-
+To initiate a digest run:
 
 ```console
-lein dry-run-weekly
+lein wet-run
 ```
 
-To initiate a daily or weekly digest run:
+To trigger a digest request, you can also use the following urls:
 
 ```console
-lein run-daily
-```
-
--or-
-
-```console
-lein run-weekly
-```
-
-To trigger a digest request you can use the following urls:
-
-```console
-http://localhost:3008/_/email/weekly
-http://localhost:3008/_/email/daily
-http://localhost:3008/_/slack/weekly
-http://localhost:3008/_/slack/daily
+http://localhost:3008/_/email/run
+http://localhost:3008/_/slack/run
 ```
 
 Obviously you can replace the domain to run it on other environments.
@@ -251,14 +237,12 @@ Obviously you can replace the domain to run it on other environments.
 
 ## Technical Design
 
-The Digest Service is composed of 4 main responsibilities:
+The Digest Service is composed of 2 main responsibilities:
 
-- Send daily email digests to users
-- Send daily Slack digests to users
-- Send weekly email digests to users
-- Send weekly Slack digests to users
+- Send a daily email digests to users in a time appropriate for their timezone
+- Send a daily Slack digests to users in a time appropriate for their timezone
 
-The Digest Service runs on a daily and weekly schedule, or a digest run can be invoked manually. It uses read-only access to the RethinkDB database of the [Authorization Service](https://github.com/open-company/open-company-auth) to enumerate users that have requested a digest. For each of those users, a digest request is generated for each organization the user has access to (most users just have 1 organization) by generating a [JSON Web Token](https://jwt.io/) for that user, using the JWToken to request a date range of activity for the particular user and the particular org from the REST API of [Storage Service](https://github.com/open-company/open-company-storage), and then generating a JSON digest request, sent via [SQS](https://aws.amazon.com/sqs/), to either the [Email Service](https://github.com/open-company/open-company-email) or [Bot Service](https://github.com/open-company/open-company-bot).
+The Digest Service runs on an hourly schedule so that users get the daily digest in their own timezone, or a digest run can be invoked manually. It uses read-only access to the RethinkDB database of the [Authorization Service](https://github.com/open-company/open-company-auth) to enumerate users. For each of those users, a digest request is generated for each organization the user has access to (most users just have 1 organization) by generating a [JSON Web Token](https://jwt.io/) for that user, using the JWToken to request a date range of activity for the particular user and the particular org from the REST API of [Storage Service](https://github.com/open-company/open-company-storage), and then generating a JSON digest request, sent via [SQS](https://aws.amazon.com/sqs/), to either the [Email Service](https://github.com/open-company/open-company-email) or [Bot Service](https://github.com/open-company/open-company-bot).
 
 
 ## Testing

--- a/project.clj
+++ b/project.clj
@@ -117,7 +117,6 @@
         :env "production"
         :db-name "open_company_auth"
         :hot-reload "false"
-        :log-level "debug"
       }
     }
 

--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
     ;; HTTP client https://github.com/dakrone/clj-http
     [clj-http "3.9.1"]
     ;; Simple scheduler https://github.com/juxt/tick
-    ;; NB: Don't upgrade to 0.4.0, it's not backward compatible as of 0.4.0-alpha on Aug. 6, 2018
+    ;; NB: Don't upgrade to +0.4, it's not backward compatible as timeline/clock/schedele namespaces all deprecated
     [tick "0.3.5"]
     ;; Clojure wrapper for Java 8 Date-Time https://github.com/dm3/clojure.java-time
     [clojure.java-time "0.3.2"]
@@ -136,6 +136,11 @@
                  '[clojure.string :as s]
                  '[rethinkdb.query :as r]
                  '[schema.core :as schema]
+                 '[java-time :as jt]
+                 '[tick.core :as tick]
+                 '[tick.timeline :as timeline]
+                 '[tick.clock :as clock]
+                 '[tick.schedule :as schedule]
                  '[oc.lib.db.common :as db-common]
                  '[oc.lib.schema :as lib-schema]
                  '[oc.lib.jwt :as jwt]

--- a/project.clj
+++ b/project.clj
@@ -117,6 +117,7 @@
         :env "production"
         :db-name "open_company_auth"
         :hot-reload "false"
+        :log-level "debug"
       }
     }
 

--- a/project.clj
+++ b/project.clj
@@ -145,6 +145,7 @@
                  '[oc.lib.schema :as lib-schema]
                  '[oc.lib.jwt :as jwt]
                  '[oc.digest.config :as config]
+                 '[oc.digest.schedule :as digest-schedule]
                  '[oc.digest.resources.user :as user-res])
       ]
     }]

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
     [clojure.java-time "0.3.2"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.31"]
+    [open-company/lib "0.16.32"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let

--- a/project.clj
+++ b/project.clj
@@ -13,16 +13,16 @@
 
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.10.0-alpha6"]
-    [org.clojure/tools.cli "0.3.7"] ; commandline parsing https://github.com/clojure/tools.cli
-    [http-kit "2.3.0"] ; Web client/server http://http-kit.org/
+    [org.clojure/clojure "1.10.0"]
+    [org.clojure/tools.cli "0.4.1"] ; commandline parsing https://github.com/clojure/tools.cli
+    [http-kit "2.4.0-alpha2"] ; Web client/server http://http-kit.org/
     ;; Web application library https://github.com/ring-clojure/ring
-    [ring/ring-devel "1.7.0-RC1"]
+    [ring/ring-devel "1.7.1"]
     ;; Web application library https://github.com/ring-clojure/ring
     ;; NB: clj-time pulled in by oc.lib
     ;; NB: joda-time pulled in by oc.lib via clj-time
     ;; NB: commons-codec pulled in by oc.lib
-    [ring/ring-core "1.7.0-RC1" :exclusions [clj-time joda-time commons-codec]]
+    [ring/ring-core "1.7.1" :exclusions [clj-time joda-time commons-codec]]
     ;; Ring logging https://github.com/nberger/ring-logger-timbre
     ;; NB: com.taoensso/encore pulled in by oc.lib
     ;; NB: com.taoensso/timbre pulled in by oc.lib
@@ -38,7 +38,7 @@
     [clojure.java-time "0.3.2"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.30"]
+    [open-company/lib "0.16.31"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let
@@ -72,13 +72,13 @@
         ;; NB: clj-time is pulled in by oc.lib
         ;; NB: joda-time is pulled in by oc.lib via clj-time
         ;; NB: commons-codec pulled in by oc.lib
-        [midje "1.9.2" :exclusions [joda-time clj-time commons-codec]] 
+        [midje "1.9.4" :exclusions [joda-time clj-time commons-codec]] 
       ]
       :plugins [
         ;; Example-based testing https://github.com/marick/lein-midje
         [lein-midje "3.2.1"]
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.2.9"]
+        [jonase/eastwood "0.3.4"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit
         [lein-kibit "0.1.6" :exclusions [org.clojure/clojure]]
       ]
@@ -107,7 +107,7 @@
         ;; Catch spelling mistakes in docs and docstrings https://github.com/cldwalker/lein-spell
         [lein-spell "0.1.0"]
         ;; Dead code finder https://github.com/venantius/yagni
-        [venantius/yagni "0.1.4" :exclusions [org.clojure/clojure]]
+        [venantius/yagni "0.1.7" :exclusions [org.clojure/clojure]]
       ]
     }]
 
@@ -154,10 +154,8 @@
 
   :aliases{
     "build" ["do" "clean," "deps," "compile"] ; clean and build code
-    "dry-run-daily" ["run" "-m" "oc.digest.cli" "-f" "daily" "--dry"] ; process a day's digest (not actually sent)
-    "dry-run-weekly" ["run" "-m" "oc.digest.cli" "-f" "weekly" "--dry"] ; process a weekly digest run (not actually sent)
-    "run-daily" ["run" "-m" "oc.digest.cli" "-f" "daily"] ; process a day's digest (actually sent)
-    "run-weekly" ["run" "-m" "oc.digest.cli" "-f" "weekly"] ; process a weekly digest run (actually sent)
+    "dry-run" ["run" "-m" "oc.digest.cli" "--dry"] ; process a day's digest (not actually sent)
+    "wet-run" ["run" "-m" "oc.digest.cli"] ; process a day's digest (actually sent)
     "start" ["do" "run" "-m" "oc.digest.app"] ; start a development server
     "start!" ["with-profile" "prod" "do" "start"] ; start a server in production
     "midje!" ["with-profile" "qa" "midje"] ; run all tests
@@ -173,7 +171,10 @@
 
   :eastwood {
     ;; Disable some linters that are enabled by default
-    :exclude-linters [:constant-test :wrong-arity]
+    ;; contant-test - just seems mostly ill-advised, logical constants are useful in something like a `->cond` 
+    ;; wrong-arity - unfortunate, but it's failing on 3/arity of sqs/send-message
+    ;; implicit-dependencies - uhh, just seems dumb
+    :exclude-linters [:constant-test :wrong-arity :implicit-dependencies]
     ;; Enable some linters that are disabled by default
     :add-linters [:unused-namespaces :unused-private-vars]
 

--- a/src/oc/digest/async/digest_request.clj
+++ b/src/oc/digest/async/digest_request.clj
@@ -29,7 +29,6 @@
 
 (def DigestTrigger
   {:type (schema/enum :digest)
-   :digest-frequency (schema/enum :daily :weekly)
    :org-slug lib-schema/NonBlankStr
    :org-name lib-schema/NonBlankStr
    :org-uuid lib-schema/UniqueID
@@ -133,9 +132,8 @@
      (assoc :last-name last-name)))))
     
 (defn ->trigger [{logo-url :logo-url org-slug :slug org-name :name org-uuid :uuid team-id :team-id :as org}
-                 activity frequency claims]
+                 activity claims]
   (let [trigger {:type :digest
-                 :digest-frequency (keyword frequency)
                  :org-slug org-slug
                  :org-name org-name
                  :org-uuid org-uuid

--- a/src/oc/digest/cli.clj
+++ b/src/oc/digest/cli.clj
@@ -4,6 +4,7 @@
   (:require
     [clojure.tools.cli :as cli]
     [oc.lib.db.pool :as db]
+    [java-time :as jt]
     [oc.digest.config :as c]
     [oc.digest.schedule :as schedule]))
 
@@ -18,6 +19,6 @@
         dry? (-> options :options :dry)
         conn (db/init-conn c/db-options)]
     (println "Enumerating users for a digest run...")
-    (schedule/digest-run conn dry?)
+    (schedule/digest-run conn (jt/zoned-date-time) dry?)
     (println "DONE\n")
     (System/exit 0)))

--- a/src/oc/digest/cli.clj
+++ b/src/oc/digest/cli.clj
@@ -10,19 +10,14 @@
 (def no-http-server -1)
 
 (def cli-options
-  ;; An option with a required argument
-  [["-f" "--frequency FREQUENCY" "'daily' -or- 'weekly'"
-    :default "daily"
-    :validate [#(or (= % "daily") (= % "weekly")) "Must be 'daily' or 'weekly'"]]
-   ;; A boolean option defaulting to nil
+  [;; A boolean option defaulting to nil
    ["-d" "--dry"]])
 
 (defn -main [& args]
   (let [options (cli/parse-opts args cli-options)
-        frequency (-> options :options :frequency)
         dry? (-> options :options :dry)
         conn (db/init-conn c/db-options)]
-    (println "Enumerating users for a" frequency "digest run...")
-    (schedule/digest-run conn (keyword frequency) dry?)
+    (println "Enumerating users for a digest run...")
+    (schedule/digest-run conn dry?)
     (println "DONE\n")
     (System/exit 0)))

--- a/src/oc/digest/resources/user.clj
+++ b/src/oc/digest/resources/user.clj
@@ -29,12 +29,14 @@
 (defn- now-for-tz [instant user]
   (let [time-for-user (jt/with-zone-same-instant instant (:timezone user))
         digest-time-for-user (jt/adjust (jt/with-zone (jt/zoned-date-time) (:timezone user)) digest-time)
-        time-for-digest? (< (Math/abs (jt/time-between time-for-user digest-time-for-user :minutes)) 59)]
+        time-delta (jt/time-between time-for-user digest-time-for-user :minutes)
+        time-for-digest? (and ; occurs now or within the next 59 mins?
+                            (or (pos? time-delta) (zero? time-delta))
+                            (< time-delta 59))]
     (timbre/debug "User" (:email user) "is in TZ:" (:timezone user) "where it is:" time-for-user)
     (timbre/debug "Digest time for user" (:email user) ":" digest-time-for-user)
-    (timbre/debug "Minutes between now and digest time for for user" (:email user) ":"
-      (jt/time-between time-for-user digest-time-for-user :minutes))
-    (timbre/debug "Digest time for user?" time-for-digest?)
+    (timbre/debug "Minutes between now and digest time for for user" (:email user) ":" time-delta)
+    (timbre/debug "Digest now for user" (:email user) "?" time-for-digest?)
   (assoc user :now? time-for-digest?)))
 
 ;; ----- Prep raw user for digest request -----

--- a/src/oc/digest/resources/user.clj
+++ b/src/oc/digest/resources/user.clj
@@ -8,9 +8,9 @@
             [oc.digest.config :as config]))
 
 (def user-props [:user-id :teams :email :first-name :last-name :avatar-url
-                 :digest-medium :digest-frequency :status :slack-users])
+                 :digest-medium :status :slack-users])
 
-(def not-for-jwt [:digest-medium :digest-frequency :status])
+(def not-for-jwt [:digest-medium :status])
 
 (def for-jwt {:auth-source :digest
               :refresh-url "N/A"})
@@ -52,9 +52,5 @@
 ;; ----- User enumeration -----
 
 (defun list-users-for-digest
-  
-  ([conn :daily]
-  (for-digest conn (db-common/read-resources conn table-name :digest-frequency :daily user-props)))
-
-  ([conn :weekly]
-  (for-digest conn (db-common/read-resources conn table-name :digest-frequency :weekly user-props))))
+  [conn]
+  (for-digest conn (db-common/read-resources conn table-name user-props)))

--- a/src/oc/digest/resources/user.clj
+++ b/src/oc/digest/resources/user.clj
@@ -4,6 +4,7 @@
             [taoensso.timbre :as timbre]
             [clj-time.core :as t]
             [clj-time.format :as format]
+            [java-time :as jt]
             [oc.lib.db.common :as db-common]
             [oc.lib.jwt :as jwt]
             [oc.digest.config :as config]))
@@ -24,9 +25,9 @@
 ;; ----- TimeZone gymnastics -----
 
 (defn- now-for-tz [instant user]
- (timbre/info (:timezone user) (:email user))
- (timbre/info instant)
- (assoc user :now? false))
+  (let [time-for-user (jt/with-zone-same-instant instant (:timezone user))]
+    (timbre/debug "User" (:email user) "is in TZ:" (:timezone user) "where it is:" time-for-user)) 
+  (assoc user :now? false))
 
 ;; ----- Prep raw user for digest request -----
 

--- a/src/oc/digest/resources/user.clj
+++ b/src/oc/digest/resources/user.clj
@@ -8,7 +8,7 @@
             [oc.digest.config :as config]))
 
 (def user-props [:user-id :teams :email :first-name :last-name :avatar-url
-                 :digest-medium :status :slack-users])
+                 :digest-medium :status :slack-users :timezone])
 
 (def not-for-jwt [:digest-medium :status])
 
@@ -45,6 +45,7 @@
   ([_user] false)) ; no digest for you!
 
 (defn- for-digest [conn users]
+  (println (str "USERS: " users))
   (->> users
     (filter allowed?)
     (pmap #(with-jwtoken conn %))))

--- a/src/oc/digest/schedule.clj
+++ b/src/oc/digest/schedule.clj
@@ -63,9 +63,9 @@
 
 ;; ----- Scheduler Component -----
 
-(defn- top-of-the-hour [] (jt/plus (jt/truncate-to (jt/zoned-date-time) :minutes) (jt/minutes 1)))
+(defn- top-of-the-hour [] (jt/plus (jt/truncate-to (jt/zoned-date-time) :hours) (jt/hours 1)))
 
-(def hourly-timeline (timeline/timeline (timeline/periodic-seq (top-of-the-hour) (tick/minutes 1)))) ; every hour
+(def hourly-timeline (timeline/timeline (timeline/periodic-seq (top-of-the-hour) (tick/hours 1)))) ; every hour
 
 (def hourly-schedule (schedule/schedule on-tick hourly-timeline))
 

--- a/src/oc/digest/schedule.clj
+++ b/src/oc/digest/schedule.clj
@@ -1,5 +1,12 @@
 (ns oc.digest.schedule
-  "CLI and scheduled digest runs."
+  "
+  CLI and scheduled digest runs.
+
+  Dependency note:
+  - Java-time lib is used for timezone aware time comparisons.
+  - Tick lib is used for scheduling.
+  - Tick deprecated the its schedule/timeline API but has not replaced it yet w/ a new design (Jan 3, 2019)
+  "
   (:require [defun.core :refer (defun)]
             [taoensso.timbre :as timbre]
             [java-time :as jt]
@@ -10,13 +17,11 @@
             [oc.lib.db.pool :as pool]
             [oc.digest.resources.user :as user-res]
             [oc.digest.data :as data])
-  (:import [org.joda.time DateTimeZone])
   (:gen-class))
 
 ;; ----- State -----
 
-(def daily-digest-schedule (atom false)) ; atom holding schedule so it can be stopped
-(def weekly-digest-schedule (atom false)) ; atom holding schedule so it can be stopped
+(def digest-schedule (atom false)) ; atom holding schedule so it can be stopped
 
 (def db-pool (atom false)) ; atom holding DB pool so it can be used in each tick of the schedule
 
@@ -47,40 +52,35 @@
 
 ;; ----- Scheduled Fns -----
 
-(defn- new-tick?
-  "Check if this is a new tick, or if it is just the scheduler catching up with now."
-  [tick]
-  (.isAfter (.plusSeconds (.toInstant tick) 60) (jt/instant)))
-
-(defn- daily-run [{tick :tick/date}]
-  (when (new-tick? tick)
-    (timbre/info "New daily digest run initiated with tick:" tick)
-    (try
-      (pool/with-pool [conn @db-pool] (digest-run conn :daily))
-      (catch Exception e
-        (timbre/error e)))))
+(defn- on-tick [{tick :tick/date}]
+  (timbre/info "New digest run initiated with tick:" tick))
+    ; (try
+    ;   (pool/with-pool [conn @db-pool] (digest-run conn))
+    ;   (catch Exception e
+    ;     (timbre/error e)))))
 
 ;; ----- Scheduler Component -----
 
-(def daily-time "7 AM EST" (jt/adjust (jt/with-zone (jt/zoned-date-time) "America/New_York") (jt/local-time 7)))
+(defn- top-of-the-hour [] (jt/plus (jt/truncate-to (jt/zoned-date-time) :hours) (jt/hours 1)))
 
-(def daily-timeline (timeline/timeline (timeline/periodic-seq daily-time (tick/days 1)))) ; every day at daily-time
+(def hourly-timeline (timeline/timeline (timeline/periodic-seq (top-of-the-hour) (tick/hours 1)))) ; every hour
 
-(def daily-schedule (schedule/schedule daily-run daily-timeline))
+(def hourly-schedule (schedule/schedule on-tick hourly-timeline))
 
 (defn start [pool]
 
   (reset! db-pool pool) ; hold onto the DB pool reference
 
-  (timbre/info "Starting daily digest schedule...")
-  (reset! daily-digest-schedule daily-schedule)
-  (schedule/start daily-schedule (clock/clock-ticking-in-seconds)))
+  (timbre/info "Starting digest schedule...")
+  (timbre/info "First run set for:" (top-of-the-hour))
+  (reset! digest-schedule hourly-schedule)
+  (schedule/start hourly-schedule (clock/clock-ticking-in-seconds)))
 
 (defn stop []
 
-  (when @daily-digest-schedule
-    (timbre/info "Stopping daily digest schedule...")
-    (schedule/stop @daily-digest-schedule)
-    (reset! daily-digest-schedule false))
+  (when @digest-schedule
+    (timbre/info "Stopping digest schedule...")
+    (schedule/stop @digest-schedule)
+    (reset! digest-schedule false))
   
   (reset! db-pool false))

--- a/test/oc/digest/unit/resources/user/user_timezone.clj
+++ b/test/oc/digest/unit/resources/user/user_timezone.clj
@@ -1,0 +1,58 @@
+(ns oc.digest.unit.resources.user.user-timezone
+  (:require [midje.sweet :refer :all]
+            [java-time :as jt]
+            [taoensso.timbre :as timbre]
+            [oc.digest.resources.user :as user]))
+
+;; ----- Test Data -----
+
+(def EST "America/New_York")
+(def CST "America/Chicago")
+(def UTC "Europe/London")
+(def half-hour "Asia/Kabul") ; UTC +4:30
+
+;; ----- Utilities -----
+
+(defn- user-in [tz] {:timezone tz})
+
+(defn- digest-for-user? [tick-timezone local-time user-timezone]
+  (:now? (#'user/now-for-tz 
+    (jt/adjust (jt/with-zone (jt/zoned-date-time) tick-timezone) (jt/local-time local-time))
+    (user-in user-timezone))))
+
+;; ----- Tests -----
+
+(facts "About digest invocation in user's timezone"
+
+  ;; Turn off debug logging
+  (timbre/merge-config! {:level (keyword :info)})
+
+  (facts "About EST"
+    (digest-for-user? EST 6 EST) => false ; schedule tick at 6AM EST
+    (digest-for-user? EST 7 EST) => true ; schedule tick at 7AM EST
+    (digest-for-user? EST 8 EST) => false ; schedule tick at 8AM EST
+    (digest-for-user? EST 19 EST) => false) ; schedule tick at 7PM EST
+
+  (facts "About CST"
+    (digest-for-user? EST 7 CST) => false ; schedule tick at 7AM EST
+    (digest-for-user? EST 8 CST) => true ; schedule tick at 8AM EST
+    (digest-for-user? EST 9 CST) => false ; schedule tick at 9AM EST
+    (digest-for-user? EST 20 CST) => false) ; schedule tick at 8PM EST
+
+  (facts "About UTC"
+    (digest-for-user? UTC 6 UTC) => false ; schedule tick at 6AM UTC
+    (digest-for-user? UTC 7 UTC) => true ; schedule tick at 7AM UTC
+    (digest-for-user? UTC 8 UTC) => false ; schedule tick at 8AM UTC
+    (digest-for-user? UTC 19 UTC) => false) ; schedule tick at 7PM UTC
+
+  (facts "About a half-hour TZ"
+    (digest-for-user? UTC 1 half-hour) => false ; schedule tick at 1AM UTC
+    (digest-for-user? UTC 2 half-hour) => true ; schedule tick at 2AM UTC
+    (digest-for-user? UTC 3 half-hour) => false ; schedule tick at 3AM UTC
+    (digest-for-user? UTC 14 half-hour) => false) ; schedule tick at 2PM UTC
+
+  (facts "Every timezone once and only once"
+    (doseq [zone (jt/available-zone-ids)]
+      (let [results (pmap #(digest-for-user? zone % zone) (range 0 24))]
+        (count (filter true? results)) => 1
+        (count (filter false? results)) => 23))))

--- a/test/oc/digest/unit/resources/user/user_timezone.clj
+++ b/test/oc/digest/unit/resources/user/user_timezone.clj
@@ -6,9 +6,10 @@
 
 ;; ----- Test Data -----
 
-(def EST "America/New_York")
-(def CST "America/Chicago")
-(def UTC "Europe/London")
+(def EST "America/New_York") ; UTC -
+(def CST "America/Chicago") ; UTC --
+(def UTC "Europe/London") ; UTC on the nose
+(def UTCplus "Australia/West") ; UTC +8
 (def half-hour "Asia/Kabul") ; UTC +4:30
 
 ;; ----- Utilities -----
@@ -27,13 +28,13 @@
   ;; Turn off debug logging
   (timbre/merge-config! {:level (keyword :info)})
 
-  (facts "About EST"
+  (facts "About EST (UTC-)"
     (digest-for-user? EST 6 EST) => false ; schedule tick at 6AM EST
     (digest-for-user? EST 7 EST) => true ; schedule tick at 7AM EST
     (digest-for-user? EST 8 EST) => false ; schedule tick at 8AM EST
     (digest-for-user? EST 19 EST) => false) ; schedule tick at 7PM EST
 
-  (facts "About CST"
+  (facts "About CST (UTC-)"
     (digest-for-user? EST 7 CST) => false ; schedule tick at 7AM EST
     (digest-for-user? EST 8 CST) => true ; schedule tick at 8AM EST
     (digest-for-user? EST 9 CST) => false ; schedule tick at 9AM EST
@@ -45,6 +46,12 @@
     (digest-for-user? UTC 8 UTC) => false ; schedule tick at 8AM UTC
     (digest-for-user? UTC 19 UTC) => false) ; schedule tick at 7PM UTC
 
+  (facts "About Australia (UTC+)"
+    (digest-for-user? UTC 22 UTCplus) => false ; schedule tick at 6AM UTC
+    (digest-for-user? UTC 23 UTCplus) => true ; schedule tick at 7AM UTC
+    (digest-for-user? UTC 0 UTCplus) => false ; schedule tick at 8AM UTC
+    (digest-for-user? UTC 11 UTCplus) => false) ; schedule tick at 7PM UTC
+  
   (facts "About a half-hour TZ"
     (digest-for-user? UTC 1 half-hour) => false ; schedule tick at 1AM UTC
     (digest-for-user? UTC 2 half-hour) => true ; schedule tick at 2AM UTC
@@ -53,6 +60,13 @@
 
   (facts "Every timezone once and only once"
     (doseq [zone (jt/available-zone-ids)]
-      (let [results (pmap #(digest-for-user? zone % zone) (range 0 24))]
-        (count (filter true? results)) => 1
-        (count (filter false? results)) => 23))))
+      (let [results (pmap #(digest-for-user? UTC % zone) (range 0 24))
+            happened (count (filter true? results))
+            not-happend (count (filter false? results))]
+         (when (and (not= 1 happened) (not= 23 not-happend))
+          (timbre/error "Failure for TZ:" zone)
+          (timbre/merge-config! {:level (keyword :debug)})
+          (doall (map #(digest-for-user? UTC % zone) (range 0 24)))
+          (timbre/merge-config! {:level (keyword :info)}))
+         happened => 1
+         not-happend => 23))))


### PR DESCRIPTION
Card: https://trello.com/c/JcvNr1Ew

This is the master PR for:

Auth - https://github.com/open-company/open-company-auth/pull/74

Web - https://github.com/open-company/open-company-web/pull/768

Email - https://github.com/open-company/open-company-email/pull/39


To test email changes:
- Login
- Create a new post
- Send yourself an email digest using the digest service test URL `/_/email/run`
- [x] did you get it by email? Good
- [x] do you NOT see the digest footer about changing settings? Good

To test Web/Auth changes:
- change all 3 of your notifications preferences
- [x] do they "stick" when you reload the app and check? No console or HTTP request errors?
- Send yourself a notification (ask another dev for help or use a 2nd user)
- [x] did you get it with the right medium? Good. Try it with the other 2 mediums too.
- [x] repeat for daily digest

Digest changes to no longer have the concept of daily/weekly, and to have a scheduled run ever hour at the top of the hour, and to send the digest (if one is needed) at 7AM local to the user's TZ.

To test Digest changes:
- Review the added unit tests
- [x] do they seem to be testing the new TZ handling well?
- Create a new post on staging
- Find the TZ that has 7AM coming up nearest to now, whenever now is https://timezonedb.com/time-zones
- Set your TZ to that timezone
- Set your digest to email or Slack
- [x]  Do you get your digest by email or Slack (whichever you picked) at the next top of the hour?