### PR TITLE
Put back in old tick check.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
     [clojure.java-time "0.3.2"]
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.16.32"]
+    [open-company/lib "0.16.33"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; defun - Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     ;; if-let - More than one binding for if/when macros https://github.com/LockedOn/if-let
@@ -72,13 +72,13 @@
         ;; NB: clj-time is pulled in by oc.lib
         ;; NB: joda-time is pulled in by oc.lib via clj-time
         ;; NB: commons-codec pulled in by oc.lib
-        [midje "1.9.5" :exclusions [joda-time clj-time commons-codec]] 
+        [midje "1.9.6" :exclusions [joda-time clj-time commons-codec]] 
       ]
       :plugins [
         ;; Example-based testing https://github.com/marick/lein-midje
         [lein-midje "3.2.1"]
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.3.4"]
+        [jonase/eastwood "0.3.5"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit
         [lein-kibit "0.1.6" :exclusions [org.clojure/clojure]]
       ]

--- a/src/oc/digest/schedule.clj
+++ b/src/oc/digest/schedule.clj
@@ -54,12 +54,19 @@
 
 ;; ----- Scheduled Fns -----
 
+
+(defn- new-tick?
+  "Check if this is a new tick, or if it is just the scheduler catching up with now."
+  [tick]
+  (.isAfter (.plusSeconds (.toInstant tick) 60) (jt/instant)))
+
 (defn- on-tick [{instant :tick/date}]
-  (timbre/info "New digest run initiated with tick:" instant)
-  (try
-    (pool/with-pool [conn @db-pool] (digest-run conn instant))
-    (catch Exception e
-      (timbre/error e))))
+  (when (new-tick? instant)
+    (timbre/info "New digest run initiated with tick:" instant)
+    (try
+      (pool/with-pool [conn @db-pool] (digest-run conn instant))
+      (catch Exception e
+        (timbre/error e)))))
 
 ;; ----- Scheduler Component -----
 


### PR DESCRIPTION
No Trello.

This just puts back in the old tick check that was wrongly removed from Digest recently. The old tick check only comes into play when using `(go)` and `(stop)` from the REPL during development. What happens is while the service is `(stop)`ed it accumulates old ticks that then fire when the service is started again with `(go)`. This just ignores those old ticks in development.

Should be a no-op for the prod servers (we had this code in before until https://github.com/open-company/open-company-digest/commit/0f6a9588fbe9437bc3623c480ee5515aed53c974). This was deployed to staging at 9:32 EST on Jan. 30, so for testing just wait until you get your next staging digest. If you get one... it's all good.
