### PR TITLE
Digest fast follow: count all reactions, not unique

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,9 +13,9 @@
 
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.10.0"]
+    [org.clojure/clojure "1.10.1-beta1"]
     [org.clojure/tools.cli "0.4.1"] ; commandline parsing https://github.com/clojure/tools.cli
-    [http-kit "2.4.0-alpha3"] ; Web client/server http://http-kit.org/
+    [http-kit "2.4.0-alpha4"] ; Web client/server http://http-kit.org/
     ;; Web application library https://github.com/ring-clojure/ring
     [ring/ring-devel "1.7.1"]
     ;; Web application library https://github.com/ring-clojure/ring
@@ -97,7 +97,7 @@
       :plugins [
         ;; Check for code smells https://github.com/dakrone/lein-bikeshed
         ;; NB: org.clojure/tools.cli is pulled in by lein-kibit
-        [lein-bikeshed "0.5.1" :exclusions [org.clojure/tools.cli]] 
+        [lein-bikeshed "0.5.2" :exclusions [org.clojure/tools.cli]] 
         ;; Runs bikeshed, kibit and eastwood https://github.com/itang/lein-checkall
         [lein-checkall "0.1.1"]
         ;; pretty-print the lein project map https://github.com/technomancy/leiningen/tree/master/lein-pprint

--- a/src/oc/digest/async/digest_request.clj
+++ b/src/oc/digest/async/digest_request.clj
@@ -141,12 +141,13 @@
                                              total-authors)
                                      (first (filter #(= (:name %) "you")
                                                     total-authors))))
+        reactions-count (apply + (map :count reaction-data))
         reactions (text/attribution 3
-                                    (count reaction-data)
+                                    reactions-count
                                     "reaction"
                                     reaction-authors-name)
         total-attribution (interaction-attribution-text 2
-                                            (+ (count reaction-data)
+                                            (+ reactions-count
                                                comment-count)
                                             "comments/reactions"
                                             total-authors-sorted)


### PR DESCRIPTION
Card: https://trello.com/c/LJrfycle

To test:
- user A: add a post and react to it
- user B: add another reaction (not the same)
- user A: add another post and add 3 reactions to it
- user B: react to it, use some of the previous reactions and add some new one
- user A: add a new post w/o reactions
- user A: request Slack digest
- [x] reactions count ok? Good
- user B: request Email digest
- [x] reactions count ok? Good
